### PR TITLE
[hal_jpege_vepu1_v2]: Fixed jpeg encode abnormal color

### DIFF
--- a/mpp/codec/rc/rc_model_v2.c
+++ b/mpp/codec/rc/rc_model_v2.c
@@ -332,6 +332,9 @@ MPP_RET bits_model_alloc(RcModelV2Ctx *ctx, EncRcTaskInfo *cfg, RK_S64 total_bit
     RK_S32 vi_scale = ctx->vi_scale;
     RK_S32 alloc_bits = 0;
 
+    if (ctx->p_sumbits == 0)
+        ctx->p_sumbits = 1;
+
     ctx->i_scale = 80 * ctx->i_sumbits / (2 * ctx->p_sumbits);
     i_scale = ctx->i_scale;
 

--- a/mpp/hal/vpu/jpege/hal_jpege_vepu1_v2.c
+++ b/mpp/hal/vpu/jpege/hal_jpege_vepu1_v2.c
@@ -217,6 +217,8 @@ static MPP_RET hal_jpege_vepu1_gen_regs_v2(void *hal, HalEncTask *task)
     /* seek length bytes data */
     jpege_seek_bits(bits, length << 3);
     /* NOTE: write header will update qtable */
+    qtable[0] = NULL;
+    qtable[1] = NULL;
     write_jpeg_header(bits, syntax, qtable);
 
     memset(regs, 0, sizeof(RK_U32) * VEPU_JPEGE_VEPU1_NUM_REGS);


### PR DESCRIPTION
# commit
```
commit 7c1f83a597dc72862e644ddd6136ea8e95aa5e97 (HEAD -> develop, justa/develop)
Author: Justa <justa.cai@akuvox.com>
Date:   Thu Nov 19 10:44:09 2020 +0800

    [rc_model_v2]: fixed continue jpeg encode cause segfault

commit 3ae4ce22d8963f4195f6e7c70d3b5e6104453497
Author: Justa <justa.cai@akuvox.com>
Date:   Thu Nov 19 10:39:52 2020 +0800

    [hal_jpege_vepu1_v2]: Fixed jpeg encode abnormal color
    
    1. Fixed uninitialized variable(qtable[2])

```

# 关联bug
- fixed #30 
- fixed #29 