### PR TITLE
[rc_model_v2]: fixed continue jpeg encode cause segfault

### DIFF
--- a/mpp/codec/rc/rc_model_v2.c
+++ b/mpp/codec/rc/rc_model_v2.c
@@ -332,6 +332,9 @@ MPP_RET bits_model_alloc(RcModelV2Ctx *ctx, EncRcTaskInfo *cfg, RK_S64 total_bit
     RK_S32 vi_scale = ctx->vi_scale;
     RK_S32 alloc_bits = 0;
 
+    if (ctx->p_sumbits == 0)
+        ctx->p_sumbits = 1;
+
     ctx->i_scale = 80 * ctx->i_sumbits / (2 * ctx->p_sumbits);
     i_scale = ctx->i_scale;
 


### PR DESCRIPTION
# 修改
1. 规避，jpeg连续编码出现段错误

# 关联bug
- fixed #30 

# 测试用例
连续JPEG编码修改不定
```
 index 4e7b45b8..03ad8a6f 100644
 --- a/test/mpi_enc_test.c
 +++ b/test/mpi_enc_test.c
 @@ -140,7 +140,7 @@ MPP_RET test_ctx_init(MpiEncTestData **data, MpiEncTestArgs *cmd)
      p->num_frames   = cmd->num_frames;
      if (cmd->type == MPP_VIDEO_CodingMJPEG && p->num_frames == 0) {
          mpp_log("jpege default encode only one frame. Use -n [num] for rc case\n");
 -        p->num_frames   = 1;
 +        p->num_frames   = 30*10;
      }
      p->gop_mode     = cmd->gop_mode;
      p->gop_len      = cmd->gop_len;
 @@ -500,6 +500,7 @@ MPP_RET test_mpp_run(MpiEncTestData *p)
                      clearerr(p->fp_input);
                      rewind(p->fp_input);
                      p->frm_eos = 0;
 +                    rewind(p->fp_output);
                      mpp_log("%p loop times %d\n", ctx, ++p->loop_times);
                      continue;
                  }
```

# 测试方法
 /app/bin/mpi_enc_test -i /tmp/1.yuv -o /tmp/1.jpg -t 8 -f 0 -w 1920 -h 1080

# 段错误
```
11-18 01:43:31.772 5706 5706 F DEBUG : Build fingerprint: 'rockchip/rk3288/XL10:9/PQ3B.190801.002/111631.910.230.101.43:userdebug/dev-keys'
11-18 01:43:31.772 5706 5706 F DEBUG : Revision: '0'
11-18 01:43:31.772 5706 5706 F DEBUG : ABI: 'arm'
11-18 01:43:31.773 5706 5706 F DEBUG : pid: 5701, tid: 5703, name: mpp_enc >>> /app/bin/mpi_enc_test <<<
11-18 01:43:31.773 5706 5706 F DEBUG : signal 8 (SIGFPE), code -6 (SI_TKILL), fault addr --------
11-18 01:43:31.773 5706 5706 F DEBUG : r0 00000000 r1 00001647 r2 00000008 r3 083522a0
11-18 01:43:31.773 5706 5706 F DEBUG : r4 083522a0 r5 00000000 r6 b2d9bd50 r7 0000010c
11-18 01:43:31.773 5706 5706 F DEBUG : r8 b29c7000 r9 000000a0 r10 0005451c r11 00000000
11-18 01:43:31.773 5706 5706 F DEBUG : ip 00771078 sp b2941550 lr b2d5e504 pc b2be47c8
11-18 01:43:31.787 5706 5706 F DEBUG :
11-18 01:43:31.787 5706 5706 F DEBUG : backtrace:
11-18 01:43:31.787 5706 5706 F DEBUG : #00 pc 000557c8 /system/lib/libc.so (tgkill+12)
11-18 01:43:31.787 5706 5706 F DEBUG : #1 pc 000d6500 /vendor/lib/libmpp.so (__aeabi_idiv0+8)
11-18 01:43:31.787 5706 5706 F DEBUG : #2 pc 000b5658 /vendor/lib/libmpp.so (bits_model_alloc+68)
11-18 01:43:31.787 5706 5706 F DEBUG : #3 pc 000b5e50 /vendor/lib/libmpp.so (calc_vbr_ratio+124)
11-18 01:43:31.788 5706 5706 F DEBUG : #4 pc 000b7810 /vendor/lib/libmpp.so (rc_model_v2_start+508)
11-18 01:43:31.788 5706 5706 F DEBUG : #5 pc 00023938 /vendor/lib/libmpp.so (mpp_enc_thread(void*)+5988)
11-18 01:43:31.788 5706 5706 F DEBUG : #6 pc 00064303 /system/lib/libc.so (__pthread_start(void*)+22)
11-18 01:43:31.788 5706 5706 F DEBUG : #7 pc 0001df8d /system/lib/libc.so (__start_thread+32)
```